### PR TITLE
Update lint.yaml

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -36,6 +36,6 @@ jobs:
         uses: actions/checkout@v3.5.2
 
       - name: 🚀 Run Home Assistant Add-on Lint
-        uses: frenck/action-addon-linter@v2.11
+        uses: frenck/action-addon-linter@v2.15.1
         with:
           path: "./${{ matrix.path }}"


### PR DESCRIPTION
This pull request includes a minor but important update to the `lint.yaml` file in the `.github/workflows` directory. The version of the `frenck/action-addon-linter` used in the Home Assistant Add-on Lint job has been updated from `v2.11` to `v2.15.1`. This update ensures that the latest features, improvements, and bug fixes of the linter are being utilized in the workflow.