### PR TITLE
Add armv7 support for ha-meterparser-addon

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-.github/* @junalmeida
+/** @junalmeida

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -62,7 +62,7 @@ jobs:
     strategy:
       matrix:
         addon: ${{ fromJson(needs.init.outputs.changed_addons) }}
-        arch: ["aarch64", "amd64"]
+        arch: ["aarch64", "amd64", "armv7"]
 
     steps:
       - name: Check out repository

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -119,7 +119,7 @@ jobs:
         addon: ${{ fromJson(needs.init.outputs.changed_addons) }}
     steps:
       - name: Check out repository
-        uses: actions/checkout
+        uses: actions/checkout@v3.5.2
       - name: Get information
         id: info
         uses: home-assistant/actions/helpers/info@master

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Build ${{ matrix.addon }} add-on
         if: steps.check.outputs.build_arch == 'true'
-        uses: home-assistant/builder@2024.01.0
+        uses: home-assistant/builder@master
         with:
           args: |
             ${{ env.BUILD_ARGS }} \
@@ -119,7 +119,7 @@ jobs:
         addon: ${{ fromJson(needs.init.outputs.changed_addons) }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3.5.2
+        uses: actions/checkout
       - name: Get information
         id: info
         uses: home-assistant/actions/helpers/info@master

--- a/meterparser/CHANGELOG.md
+++ b/meterparser/CHANGELOG.md
@@ -1,3 +1,5 @@
+### [1.0.2.6]
+- Add armv7 support
 ### [1.0.2.5]
 
 - Reduce ffmpeg logs, reduce amount of time to seek for a snapshot

--- a/meterparser/build.yaml
+++ b/meterparser/build.yaml
@@ -1,6 +1,6 @@
 build_from:
-  aarch64: ghcr.io/hassio-addons/debian-base/aarch64:5.3.1
-  amd64: ghcr.io/hassio-addons/debian-base/amd64:5.3.1
-  # armhf: ghcr.io/hassio-addons/debian-base/armhf:5.3.1
-  armv7: ghcr.io/hassio-addons/debian-base/armv7:5.3.1
-  # i386: ghcr.io/hassio-addons/debian-base/i386:5.3.1
+  aarch64: ghcr.io/hassio-addons/debian-base/aarch64:7.3.1
+  amd64: ghcr.io/hassio-addons/debian-base/amd64:7.3.1
+  # armhf: ghcr.io/hassio-addons/debian-base/armhf:7.3.1
+  armv7: ghcr.io/hassio-addons/debian-base/armv7:7.3.1
+  # i386: ghcr.io/hassio-addons/debian-base/i386:7.3.1

--- a/meterparser/build.yaml
+++ b/meterparser/build.yaml
@@ -2,5 +2,5 @@ build_from:
   aarch64: ghcr.io/hassio-addons/debian-base/aarch64:5.3.1
   amd64: ghcr.io/hassio-addons/debian-base/amd64:5.3.1
   # armhf: ghcr.io/hassio-addons/debian-base/armhf:5.3.1
-  # armv7: ghcr.io/hassio-addons/debian-base/armv7:5.3.1
+  armv7: ghcr.io/hassio-addons/debian-base/armv7:5.3.1
   # i386: ghcr.io/hassio-addons/debian-base/i386:5.3.1

--- a/meterparser/config.yaml
+++ b/meterparser/config.yaml
@@ -1,5 +1,5 @@
 name: Meter Parser
-version: 1.0.2.5
+version: 1.0.2.6
 slug: meter-parser
 description: Read meter needles and numbers from a camera snapshot.
 url: https://github.com/junalmeida/homeassistant-addons/tree/main/meterparser


### PR DESCRIPTION
This pull request adds support for the armv7 platform to the ha-meterparser-addon. This allows users with armv7 devices to install and use the addon successfully.

Fixes #86